### PR TITLE
Refactor the CLI

### DIFF
--- a/aws_tags_exporter.go
+++ b/aws_tags_exporter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -144,7 +145,16 @@ func main() {
 	Excludes := make(collectorSet)
 	flag.Var(&Excludes, "exclude", "Comma-separated list to exclude from all available collectors")
 
+	List := flag.Bool("list", false, "List all available collectors")
+
 	flag.Parse()
+
+	if *List {
+		cs := getCollectorsAfterExclude(collectorSet{})
+		fmt.Println("Available Collectors: ")
+		fmt.Println(cs.String())
+		return
+	}
 
 	if *Region == "" {
 		glog.Exit("Please supply a region")

--- a/aws_tags_exporter.go
+++ b/aws_tags_exporter.go
@@ -102,7 +102,7 @@ func main() {
 	flag.Parse()
 
 	if *Region == "" {
-		glog.Fatal("Please supply a region")
+		glog.Exit("Please supply a region")
 	}
 
 	collectorRegistry := registryCollection{


### PR DESCRIPTION
* Change the Fatal log when no region provided to an Exit log to avoid stack trace
* Add include and exclude flags to specify the collectors that should be run
* Add a list flag to list available collectors